### PR TITLE
New: add jsExtension option

### DIFF
--- a/Installer/Distribution/Defaults/pipeline.yaml
+++ b/Installer/Distribution/Defaults/pipeline.yaml
@@ -13,6 +13,7 @@
 # inline                  <boolean>       (default: `false`) Flag to toggle if the files should be written to `Resources/Private/Templates/InlineAssets`
 # sourcemap               <boolean>       (default: `true`) Flag to toggle source map generation
 # format                  <string>        (default: `iife`)
+# jsExtension             <string>        (default: `null`) You can define the output extension of esbuild. `null` matches the format option (esm=.mjs, cjs=.cjs, iife=.js)
 
 packages:
   - package: Vendor.Bar

--- a/Lib/helper.mjs
+++ b/Lib/helper.mjs
@@ -118,12 +118,14 @@ function argv(key) {
 function scriptEntryConfig(entry, entryPoints, type, format = null) {
     const conf = entryConfig(entry, type);
     const external = toArray(entry.external || config.buildDefaults.external) || [];
+    const jsExtension = entry.jsExtension || null;
     format = format || entry.format || config.buildDefaults.format;
 
     return {
         entryPoints,
         format,
         external,
+        jsExtension,
         ...conf,
     };
 }

--- a/Readme.md
+++ b/Readme.md
@@ -119,6 +119,7 @@ A package entry has the following options:
 | `inline`                 | `boolean`           | Flag to toggle if the files should be inlined. If set, sourcemaps are disabled                   | `true`               |
 | `sourcemap`              | `boolean`           | Flag to toggle source map generation                                                             | `false`              |
 | `format`                 | `string`            | Set the format of the output file. [Read more][esbuild format]                                   | `cjs`                |
+| `jsExtension`            | `string`            | Output extension of js files. Defaults to defined format option: esm=.mjs, cjs=.cjs, iife=.js)   | `.js`                |
 
 These are the default values for the folders:
 
@@ -140,6 +141,7 @@ external: null
 inline: false
 sourcemap: true
 format: iife
+jsExtension: null
 ```
 
 The target folders can be adjusted under the key `folder.output`. If you want to change the defaults for all your packages, you can also set this globally in your [`pipeline.yaml`]:

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -5,8 +5,8 @@ import { browserlist, options, writeFilesToAnotherPackage, importPlugins, flowSe
 async function build() {
     // Pre-import plugins
     const plugins = await importPlugins();
-    await asyncForEach(files, async ({ entryPoints, sourcemap, outdir, format, external, inline }) => {
-        const jsExtension = format === "esm" ? ".mjs" : format === "cjs" ? ".cjs" : ".js";
+    await asyncForEach(files, async ({ entryPoints, sourcemap, outdir, format, external, jsExtension, inline }) => {
+        jsExtension = jsExtension || (format === "esm" ? ".mjs" : format === "cjs" ? ".cjs" : ".js");
         const firstOutdir = outdir[0];
         const multiplePackages = outdir.length > 1;
         const write = compression ? inline : !multiplePackages;


### PR DESCRIPTION
Prevent `esm` code to always default to `.mjs`. This is not always desired, as support for `.mjs` is [not stable everywhere](https://github.com/nginx/nginx/pull/77).